### PR TITLE
automatisch das datum anzeigen

### DIFF
--- a/Kapitel/A2_Erklaerung.tex
+++ b/Kapitel/A2_Erklaerung.tex
@@ -9,7 +9,7 @@
 Hiermit bestätige ich, dass ich die vorliegende Arbeit persönlich und selbständig verfasst und keine anderen als die angegebenen Quellen und Hilfsmittel verwendet habe. Alle Stellen, die wörtlich oder sinngemäß anderen Quellen entnommen wurden, sind als solche kenntlich gemacht. Die Zeichnungen, Abbildungen und Tabellen in dieser Arbeit sind von mir selbst erstellt oder wurden mit einem entsprechenden Quellennachweis versehen. Diese Arbeit wurde weder in gleicher noch in ähnlicher Form von mir an anderen Hochschulen zur Erlangung eines akademischen Abschlusses eingereicht.
 
 \vspace{2cm}
-Fankfurt, den \dotfill
+Fankfurt, den \today \dotfill
 
 \hspace{10cm} {\footnotesize \fullname}
 


### PR DESCRIPTION
Hallo!

Aktuell muss man in `Kapitel/A2_Erklaerung.tex` per hand das Datum der abgabe eintragen, bevor man die Arbeit abschickt. 

Es wäre super, wenn dafür der `\today`-Befehl verwendet werden würde, da dieser das Datum der Kompilierung einträgt und somit diesen Schritt automatisch erfüllt.

Anbei diese Änderung.