### PR TITLE
Fixed minor spelling mistake in A2_Erklaerung.tex

### DIFF
--- a/Kapitel/A2_Erklaerung.tex
+++ b/Kapitel/A2_Erklaerung.tex
@@ -9,7 +9,7 @@
 Hiermit bestätige ich, dass ich die vorliegende Arbeit persönlich und selbständig verfasst und keine anderen als die angegebenen Quellen und Hilfsmittel verwendet habe. Alle Stellen, die wörtlich oder sinngemäß anderen Quellen entnommen wurden, sind als solche kenntlich gemacht. Die Zeichnungen, Abbildungen und Tabellen in dieser Arbeit sind von mir selbst erstellt oder wurden mit einem entsprechenden Quellennachweis versehen. Diese Arbeit wurde weder in gleicher noch in ähnlicher Form von mir an anderen Hochschulen zur Erlangung eines akademischen Abschlusses eingereicht.
 
 \vspace{2cm}
-Fankfurt, den \today \dotfill
+Frankfurt, den \today \dotfill
 
 \hspace{10cm} {\footnotesize \fullname}
 


### PR DESCRIPTION
Es war ein kleiner Rechtschreibfehler in der Eigenständigkeitserklärung, welcher anscheinend noch niemandem aufgefallen ist.

Fankfurt -> Frankfurt